### PR TITLE
Imp: initial commit of full and minimal compose scenarios

### DIFF
--- a/distributions/docker/compose/full-compose.yml
+++ b/distributions/docker/compose/full-compose.yml
@@ -1,0 +1,95 @@
+version: '3'
+services:
+  nfvo:
+    image: openbaton/nfvo:3.2.1
+    depends_on:
+      - rabbitmq_broker
+      - nfvo_database
+    restart: always
+    environment: 
+      - NFVO_RABBIT_BROKERIP=${HOST_IP} # for use in userdata.sh in vnfm-generic
+      - NFVO_MONITORING_IP=${ZABBIX_IP}
+      - SPRING_RABBITMQ_HOST=rabbitmq_broker
+      - SPRING_DATASOURCE_URL=jdbc:mysql://nfvo_database:3306/openbaton
+      - SPRING_DATASOURCE_DRIVER-CLASS-NAME=com.mysql.jdbc.Driver
+      - SPRING_JPA_DATABASE-PLATFORM=org.hibernate.dialect.MySQLDialect
+    ports:
+      - "8080:8080"
+  vnfm-generic:
+    image: openbaton/vnfm-generic:3.2.1
+    depends_on:
+      - nfvo
+    restart: always
+    environment: 
+      - VNFM_RABBITMQ_BROKERIP=rabbitmq_broker
+  zabbix-plugin:
+    image: openbaton/plugin-monitoring-zabbix:3.2.3
+    depends_on:
+      - nfvo
+    restart: always
+    hostname: openbaton-monitoring
+    environment:
+      - ZABBIX-PLUGIN-IP=zabbix-plugin
+      - ZABBIX-HOST=${ZABBIX_IP}
+      - RABBITMQ_BROKERIP=rabbitmq_broker
+    ports:
+      - "8010:8010"
+  ase:
+    image: openbaton/ase:1.2.3
+    depends_on:
+      - zabbix-plugin
+    restart: always
+    environment:
+      - AUTOSCALING_RABBITMQ_BROKERIP=rabbitmq_broker
+      - AUTOSCALING_SERVER_IP=ase
+      - NFVO_IP=nfvo
+      - PLUGIN_IP=zabbix-plugin
+    ports:
+      - "9998:9998"
+      - "9999:9999"
+  nse:
+    image: openbaton/nse:1.1.3
+    depends_on:
+      - nfvo
+    restart: always
+    environment:
+      - NFVO_IP=nfvo
+      - RABBITMQ_HOST=rabbitmq_broker
+    ports:
+      - "8082:8082"
+  # external services, mysql and rabbitmq
+  fms:
+    image: openbaton/fms:1.2.5
+    depends_on:
+      - fm_database
+      - zabbix-plugin
+    restart: always
+    environment:
+      - NFVO_IP=nfvo
+      - SPRING_RABBITMQ_HOST=rabbitmq_broker
+      - SPRING_DATASOURCE_URL=jdbc:mysql://fm_database:3306/faultmanagement
+    ports:
+      - "9000:9000"
+  fm_database:
+    image: mysql/mysql-server
+    environment:
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - MYSQL_DATABASE=faultmanagement
+      - MYSQL_USER=fmsuser
+      - MYSQL_PASSWORD=changeme
+  nfvo_database:
+    image: mysql/mysql-server
+    environment:
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - MYSQL_DATABASE=openbaton
+      - MYSQL_USER=admin
+      - MYSQL_PASSWORD=changeme
+  rabbitmq_broker:
+    image: rabbitmq:3-management-alpine
+    hostname: openbaton-rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=openbaton
+    ports:
+      - "5672:5672"
+      - "15672:15672"

--- a/distributions/docker/compose/min-compose.yml
+++ b/distributions/docker/compose/min-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+services:
+  nfvo:
+    image: openbaton/nfvo:3.2.1
+    depends_on:
+      - rabbitmq_broker
+      - nfvo_database
+    restart: always
+    environment: 
+      - NFVO_RABBIT_BROKERIP=${HOST_IP} # for use in userdata.sh in vnfm-generic
+      - NFVO_MONITORING_IP=${ZABBIX_IP}
+      - SPRING_RABBITMQ_HOST=rabbitmq_broker
+      - SPRING_DATASOURCE_URL=jdbc:mysql://nfvo_database:3306/openbaton
+      - SPRING_DATASOURCE_DRIVER-CLASS-NAME=com.mysql.jdbc.Driver
+      - SPRING_JPA_DATABASE-PLATFORM=org.hibernate.dialect.MySQLDialect
+    ports:
+      - "8080:8080"
+  vnfm-generic:
+    image: openbaton/vnfm-generic:3.2.1
+    depends_on:
+      - nfvo
+    restart: always
+    environment: 
+      - VNFM_RABBITMQ_BROKERIP=rabbitmq_broker
+  nfvo_database:
+    image: mysql/mysql-server
+    environment:
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - MYSQL_DATABASE=openbaton
+      - MYSQL_USER=admin
+      - MYSQL_PASSWORD=changeme
+  rabbitmq_broker:
+    image: rabbitmq:3-management-alpine
+    hostname: openbaton-rabbitmq
+    environment:
+      - RABBITMQ_DEFAULT_USER=admin
+      - RABBITMQ_DEFAULT_PASS=openbaton
+    ports:
+      - "5672:5672"
+      - "15672:15672"


### PR DESCRIPTION
Adds two compose yml's, one with a minimal setup (nfvo, gvnfm, mysql and rabbitmq) and one with all additional java components (nse, fms, ase, zabbix-plugin)

Needs the following env variables to be set on deploy:
`ZABBIX_IP` where zabbix 3.0 is deployed, for monitoring
`HOST_IP` where the composition is deployed, so the external ip is set correctly 