### PR TITLE
Fix: non-localpath volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - "5672:5672"
       - "15672:15672"
     volumes:
-      - ./dbdata_rabbit:/var/lib/rabbitmq
+      - dbdata_rabbit:/var/lib/rabbitmq
   nfvo_database:
     image: mysql/mysql-server:5.7.20
     environment:
@@ -64,7 +64,7 @@ services:
       - MYSQL_USER=admin
       - MYSQL_PASSWORD=changeme
     volumes:
-      - ./dbdata_nfvo:/var/lib/mysql
+      - dbdata_nfvo:/var/lib/mysql
 volumes:
   dbdata_nfvo:
   dbdata_rabbit:


### PR DESCRIPTION
Have volumes created under /var/lib/docker/volumes so `docker-compose [...] down -v` takes care of the deletion, breaks current integration-test configuration otherwise.